### PR TITLE
feat: add image optimization and viewport prefetch

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -48,8 +48,12 @@ export default defineConfig({
     },
   },
   image: {
-    responsiveStyles: true,
+    // Default layout for all images (can be overridden per-component)
     layout: "constrained",
+    // Enable CSS for responsive image resizing
+    responsiveStyles: true,
+    // Breakpoints for srcset generation (common device widths)
+    breakpoints: [640, 750, 828, 1080, 1200, 1920],
   },
   env: {
     schema: {

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -15,6 +15,7 @@ const { title, description } = data;
 <li class="my-6">
   <a
     href={getPath(id, filePath)}
+    data-astro-prefetch="viewport"
     class:list={[
       "inline-block text-lg font-medium text-accent",
       "decoration-dashed underline-offset-4 hover:underline",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,7 @@ import Header from "@/components/Header.astro";
 import Footer from "@/components/Footer.astro";
 import Card from "@/components/Card.astro";
 import getSortedPosts from "@/utils/getSortedPosts";
+import { Picture } from "astro:assets";
 import bannerImage from "@/assets/images/pascalandy-banner.jpg";
 
 const posts = await getCollection("blog");
@@ -18,8 +19,10 @@ const recentPosts = sortedPosts.filter(({ data }) => !data.featured);
   <Header />
   <main id="main-content" data-layout="index" class="app-layout">
     <section id="hero" class="pt-8 pb-6">
-      <img
-        src={bannerImage.src}
+      <Picture
+        src={bannerImage}
+        formats={["avif", "webp"]}
+        loading="eager"
         alt="Pascal Andy"
         class="mb-6 w-full rounded-lg"
       />


### PR DESCRIPTION
## Summary

- Add responsive image breakpoints and modern format generation (AVIF/WebP)
- Replace banner `<img>` with `<Picture />` component for automatic optimization
- Add viewport prefetch to Card links for faster page navigation

## Changes

| File | Change |
|------|--------|
| `astro.config.ts` | Added `breakpoints` array for responsive srcset generation |
| `src/pages/index.astro` | Replaced raw `<img>` with `<Picture />` (AVIF → WebP → JPG fallback) |
| `src/components/Card.astro` | Added `data-astro-prefetch="viewport"` for eager prefetch |

## Results

| Metric | Before | After |
|--------|--------|-------|
| Banner formats | JPG only | AVIF, WebP, JPG |
| Banner size (AVIF) | 488KB | 18-101KB |
| Responsive sizes | 1 | 6 breakpoints |
| Prefetch strategy | Hover only | Viewport (prefetch as you scroll) |

## Generated HTML

```html
<picture>
  <source srcset="...avif 640w, 750w, 828w, 1080w, 1200w, 1920w" type="image/avif">
  <source srcset="...webp 640w, ..." type="image/webp">
  <img src="...jpg" srcset="..." loading="eager" ...>
</picture>
```

## Notes

- Banner uses `loading="eager"` (above the fold)
- Markdown images in `src/` are auto-optimized via global config
- Images in `public/` remain unchanged (expected behavior)