### PR TITLE
fix(search): autofocus input on page load

### DIFF
--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -53,6 +53,12 @@ const backUrl = SITE.showBackButton ? `${Astro.url.pathname}` : "/";
         },
       });
 
+      // Focus the search input for immediate typing
+      const searchInputEl = document.querySelector<HTMLInputElement>(
+        ".pagefind-ui__search-input"
+      );
+      searchInputEl?.focus();
+
       // If search param exists (eg: search?q=astro), trigger search
       const query = params.get("q");
       if (query) {


### PR DESCRIPTION
## Summary
- Autofocus the search input when `/search` page loads
- Users can start typing immediately without clicking

## Test plan
- [ ] Navigate to `/search`
- [ ] Verify cursor is in search box (blinking caret visible)
- [ ] Type a query without clicking first
- [ ] Navigate away and back to verify it works on page transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)