### PR TITLE
test: verify CI catches wrong image paths

### DIFF
--- a/src/data/blog/test-wrong-image-path.md
+++ b/src/data/blog/test-wrong-image-path.md
@@ -1,0 +1,17 @@
+---
+title: "Test Post - Wrong Image Path"
+pubDatetime: 2026-01-15T10:00:00Z
+date_created: 2026-01-15
+author: Pascal Andy
+description: "Testing if CI catches incorrect image paths"
+tags:
+  - dev-notes
+---
+
+This is a test post with an intentionally wrong image path.
+
+## Wrong path (single ../)
+
+![test-image](../assets/images/og-legacy/2017/11/rsvp-2.jpg)
+
+This should fail because the correct path needs two `../` not one.


### PR DESCRIPTION
## Summary
- Test post with intentionally wrong image path (single `../` instead of `../../`)
- Purpose: verify if CI catches broken image references

## Expected outcome
CI should fail on the broken image path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)