### PR TITLE
feat(homepage): use legacy 2017 banner image

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,7 +6,7 @@ import Footer from "@/components/Footer.astro";
 import Card from "@/components/Card.astro";
 import getSortedPosts from "@/utils/getSortedPosts";
 import { Picture } from "astro:assets";
-import bannerImage from "@/assets/images/pascalandy-banner.jpg";
+import bannerImage from "@/assets/images/og-legacy/2017/04/pascalandy-com_header_2017-04-10_14h46.jpg";
 
 const posts = await getCollection("blog");
 


### PR DESCRIPTION
## Summary
- Switch homepage banner to the classic 2017/04 header image (`pascalandy-com_header_2017-04-10_14h46.jpg`)

## Test plan
- [ ] Verify homepage displays the legacy banner image
- [ ] Check image renders correctly on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)