### PR TITLE
fix: extract PR number from release-please output for auto-merge

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,8 +20,8 @@ jobs:
           manifest-file: .release-please-manifest.json
 
       - name: Enable auto-merge for release PR
-        if: steps.release.outputs.pr
-        run: gh pr merge ${{ steps.release.outputs.pr }} --auto --squash
+        if: steps.release.outputs.prs_created == 'true'
+        run: gh pr merge ${{ fromJSON(steps.release.outputs.pr).number }} --auto --squash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
Fix the release-please workflow auto-merge step to correctly extract the PR number.

The `steps.release.outputs.pr` returns a JSON object, not just the PR number. This fix:
- Uses `prs_created == 'true'` for the condition
- Extracts the PR number with `fromJSON(steps.release.outputs.pr).number`