### PR TITLE
feat(ci): add workflow_dispatch trigger for manual runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths-ignore:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to CI workflow
- Allows manual triggering of CI for PRs that only modify files in paths-ignore (like CHANGELOG.md)
- Fixes the issue where release-please PRs can't pass required status checks

## Context
PR #35 (release-please v0.2.0) is blocked because:
1. It only modifies CHANGELOG.md
2. CI workflow has `paths-ignore: ["*.md"]` which skips the Build check
3. Branch ruleset requires Build check to pass
4. This creates a deadlock for release PRs