### PR TITLE
fix(ci): include CHANGELOG.md in CI triggers for release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,12 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, labeled]
+    # Note: paths-ignore is skipped for release-please branches to ensure
+    # required status checks run on CHANGELOG-only PRs
     paths-ignore:
       - "*.md"
       - "!src/**/*.md"
+      - "!CHANGELOG.md"
       - "LICENSE"
       - ".vscode/**"
       - ".github/*.md"


### PR DESCRIPTION
## Summary
- Adds `!CHANGELOG.md` exception to paths-ignore for pull_request trigger
- Ensures CI runs on release-please PRs that only modify CHANGELOG.md
- Fixes the deadlock where release PRs can't pass required status checks

## Context
Release-please PRs only modify CHANGELOG.md, which was being ignored by CI.
This caused PR #35 to be blocked because the required 'Build' check never ran.