### PR TITLE
fix(ci): always run CI on PRs to satisfy required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,7 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, labeled]
-    # Note: paths-ignore is skipped for release-please branches to ensure
-    # required status checks run on CHANGELOG-only PRs
-    paths-ignore:
-      - "*.md"
-      - "!src/**/*.md"
-      - "!CHANGELOG.md"
-      - "LICENSE"
-      - ".vscode/**"
-      - ".github/*.md"
-      - ".github/ISSUE_TEMPLATE/**"
-      - "dev_notes/**"
+    # No paths-ignore: always run CI on PRs to satisfy required status checks
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Removes `paths-ignore` from the pull_request trigger so CI always runs on PRs.

## Why
- Branch protection requires Build + gitleaks checks
- Release-please PRs only modify CHANGELOG.md/package.json
- paths-ignore was preventing CI from running on these PRs
- Result: release PRs were permanently blocked

## Solution
PRs should always run CI - it's a safety measure (1-2 min). 
Keep paths-ignore only for push events to avoid unnecessary deploys.