### PR TITLE
fix(css): make YouTube iframes responsive on mobile

### DIFF
--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -48,6 +48,12 @@
       height: auto;
     }
 
+    iframe {
+      @apply mx-auto max-w-full border border-border;
+      aspect-ratio: 16 / 9;
+      height: auto;
+    }
+
     figcaption {
       @apply opacity-75;
     }


### PR DESCRIPTION
## Summary
- Add responsive styles for iframes in `.app-prose` typography
- Fix horizontal overflow on mobile caused by fixed 560px YouTube embeds
- Use `max-width: 100%` and `aspect-ratio: 16/9` to maintain proper dimensions