### PR TITLE
refactor(toc): simplify table of contents component

### DIFF
--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -11,23 +11,21 @@ type Props = {
 
 const { headings } = Astro.props;
 
-// Filter to h2 and h3 only
-const tocHeadings = headings.filter(h => h.depth >= 2 && h.depth <= 3);
+// Filter to h2 only
+const tocHeadings = headings.filter(h => h.depth === 2);
 ---
 
 {
-  tocHeadings.length > 0 && (
-    <details class="mt-8 mb-4">
-      <summary class="cursor-pointer">Table of Contents</summary>
-      <ul class="mt-2 space-y-1 border border-border/50 bg-(--astro-code-background) p-4 text-muted-foreground">
+  tocHeadings.length >= 4 && (
+    <nav aria-label="Table des matières" class="app-prose my-8">
+      <h2>Table des matières</h2>
+      <ul class="list-disc pl-4">
         {tocHeadings.map(heading => (
-          <li class:list={[heading.depth === 3 && "ml-4"]}>
-            <a href={`#${heading.slug}`} class="hover:text-foreground">
-              {heading.text}
-            </a>
+          <li>
+            <a href={`#${heading.slug}`}>{heading.text}</a>
           </li>
         ))}
       </ul>
-    </details>
+    </nav>
   )
 }


### PR DESCRIPTION
## Summary
- Show TOC only when 4+ H2 headings exist (was: any heading)
- Remove accordion behavior (always visible)
- Use app-prose class for consistent styling with article content
- Add visible "Table des matières" title
- Filter to H2 headings only (removed H3)

## Test plan
- [ ] Visit article with 4+ H2 headings → TOC visible
- [ ] Visit article with <4 H2 headings → no TOC
- [ ] Verify bullet styling matches article bullets
- [ ] Test dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)