### PR TITLE
⚡️ perf(cache): add local filesystem cache for OG images and fonts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,8 @@ jobs:
       - name: Cache Astro build artifacts
         uses: actions/cache@v4
         with:
-          path: .astro-cache
-          key: astro-cache-${{ runner.os }}-${{ hashFiles('src/assets/**/*', 'astro.config.ts') }}
+          path: cache
+          key: astro-cache-${{ runner.os }}-${{ hashFiles('src/assets/**/*', 'astro.config.ts', 'src/config.ts') }}
           restore-keys: |
             astro-cache-${{ runner.os }}-
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,14 +4,11 @@ to_import/
 
 # ai dev
 
-# caching
-.astro-cache/
+# astro build cache (images, OG images, fonts)
+cache/
 
 # generated types
 .astro/
-
-# astro build cache
-.astro-cache/
 
 # dependencies
 node_modules/

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -14,7 +14,7 @@ import { SITE } from "./src/config";
 // https://astro.build/config
 export default defineConfig({
   site: SITE.website,
-  cacheDir: "./.astro-cache",
+  cacheDir: "./cache",
   integrations: [
     sitemap(),
     astroBrokenLinksChecker({

--- a/justfile
+++ b/justfile
@@ -71,8 +71,8 @@ ci:
 
 # Remove build artifacts and cache
 clean:
-    rm -rf dist node_modules/.cache .astro
+    rm -rf dist cache .astro
 
 # Deep clean before archiving workspace (removes node_modules)
 archive:
-    rm -rf dist node_modules .astro
+    rm -rf dist node_modules cache .astro

--- a/src/utils/fontCache.ts
+++ b/src/utils/fontCache.ts
@@ -10,11 +10,20 @@ function ensureFontCacheDir(): void {
   }
 }
 
-export function getFontCacheKey(font: string, weight: number): string {
+export function getFontCacheKey(
+  font: string,
+  weight: number,
+  style: string,
+  textHash: string
+): string {
   return createHash("sha256")
-    .update(`${font}-${weight}`)
+    .update(`${font}-${weight}-${style}-${textHash}`)
     .digest("hex")
     .slice(0, 12);
+}
+
+export function hashText(text: string): string {
+  return createHash("sha256").update(text).digest("hex").slice(0, 8);
 }
 
 export function getCachedFont(cacheKey: string): ArrayBuffer | null {

--- a/src/utils/fontCache.ts
+++ b/src/utils/fontCache.ts
@@ -1,0 +1,37 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const FONT_CACHE_DIR = "cache/fonts";
+
+function ensureFontCacheDir(): void {
+  if (!existsSync(FONT_CACHE_DIR)) {
+    mkdirSync(FONT_CACHE_DIR, { recursive: true });
+  }
+}
+
+export function getFontCacheKey(font: string, weight: number): string {
+  return createHash("sha256")
+    .update(`${font}-${weight}`)
+    .digest("hex")
+    .slice(0, 12);
+}
+
+export function getCachedFont(cacheKey: string): ArrayBuffer | null {
+  const cachePath = join(FONT_CACHE_DIR, `${cacheKey}.ttf`);
+  if (existsSync(cachePath)) {
+    const buffer = readFileSync(cachePath);
+    // Convert Buffer to ArrayBuffer
+    return buffer.buffer.slice(
+      buffer.byteOffset,
+      buffer.byteOffset + buffer.byteLength
+    ) as ArrayBuffer;
+  }
+  return null;
+}
+
+export function cacheFont(cacheKey: string, fontBuffer: ArrayBuffer): void {
+  ensureFontCacheDir();
+  const cachePath = join(FONT_CACHE_DIR, `${cacheKey}.ttf`);
+  writeFileSync(cachePath, new Uint8Array(fontBuffer));
+}

--- a/src/utils/generateOgImages.ts
+++ b/src/utils/generateOgImages.ts
@@ -2,12 +2,15 @@ import { Resvg } from "@resvg/resvg-js";
 import { type CollectionEntry } from "astro:content";
 import postOgImage from "./og-templates/post";
 import siteOgImage from "./og-templates/site";
-import { ACTIVE_THEME } from "@/config";
+import { SITE, ACTIVE_THEME } from "@/config";
 import {
   generateCacheKey,
   getCachedOgImage,
   cacheOgImage,
 } from "./ogImageCache";
+
+// Bump when site OG template changes
+const SITE_OG_VERSION = "v1";
 
 function svgBufferToPngBuffer(svg: string) {
   const resvg = new Resvg(svg);
@@ -18,7 +21,8 @@ function svgBufferToPngBuffer(svg: string) {
 export async function generateOgImageForPost(post: CollectionEntry<"blog">) {
   const cacheKey = generateCacheKey(
     post.data.title,
-    post.data.date_created,
+    post.data.author,
+    SITE.title,
     ACTIVE_THEME
   );
 
@@ -36,10 +40,11 @@ export async function generateOgImageForPost(post: CollectionEntry<"blog">) {
 }
 
 export async function generateOgImageForSite() {
-  // Site OG rarely changes, use static cache key
+  // Site OG cache key includes site metadata
   const cacheKey = generateCacheKey(
-    "site-og",
-    new Date("2024-01-01"),
+    SITE.title,
+    SITE.author,
+    SITE_OG_VERSION,
     ACTIVE_THEME
   );
 

--- a/src/utils/generateOgImages.ts
+++ b/src/utils/generateOgImages.ts
@@ -2,6 +2,12 @@ import { Resvg } from "@resvg/resvg-js";
 import { type CollectionEntry } from "astro:content";
 import postOgImage from "./og-templates/post";
 import siteOgImage from "./og-templates/site";
+import { ACTIVE_THEME } from "@/config";
+import {
+  generateCacheKey,
+  getCachedOgImage,
+  cacheOgImage,
+} from "./ogImageCache";
 
 function svgBufferToPngBuffer(svg: string) {
   const resvg = new Resvg(svg);
@@ -10,11 +16,40 @@ function svgBufferToPngBuffer(svg: string) {
 }
 
 export async function generateOgImageForPost(post: CollectionEntry<"blog">) {
+  const cacheKey = generateCacheKey(
+    post.data.title,
+    post.data.date_created,
+    ACTIVE_THEME
+  );
+
+  // Check cache first
+  const cached = getCachedOgImage(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  // Generate and cache
   const svg = await postOgImage(post);
-  return svgBufferToPngBuffer(svg);
+  const png = svgBufferToPngBuffer(svg);
+  cacheOgImage(cacheKey, png);
+  return png;
 }
 
 export async function generateOgImageForSite() {
+  // Site OG rarely changes, use static cache key
+  const cacheKey = generateCacheKey(
+    "site-og",
+    new Date("2024-01-01"),
+    ACTIVE_THEME
+  );
+
+  const cached = getCachedOgImage(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
   const svg = await siteOgImage();
-  return svgBufferToPngBuffer(svg);
+  const png = svgBufferToPngBuffer(svg);
+  cacheOgImage(cacheKey, png);
+  return png;
 }

--- a/src/utils/ogImageCache.ts
+++ b/src/utils/ogImageCache.ts
@@ -1,0 +1,38 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const CACHE_DIR = "cache/og-images";
+
+function ensureCacheDir(): void {
+  if (!existsSync(CACHE_DIR)) {
+    mkdirSync(CACHE_DIR, { recursive: true });
+  }
+}
+
+export function generateCacheKey(
+  title: string,
+  date: Date,
+  theme: string
+): string {
+  const content = `${title}-${date.toISOString()}-${theme}`;
+  return createHash("sha256").update(content).digest("hex").slice(0, 16);
+}
+
+export function getCachedOgImage(cacheKey: string): Buffer | null {
+  const cachePath = join(CACHE_DIR, `${cacheKey}.png`);
+  if (existsSync(cachePath)) {
+    return readFileSync(cachePath);
+  }
+  return null;
+}
+
+export function cacheOgImage(
+  cacheKey: string,
+  pngBuffer: Buffer | Uint8Array
+): void {
+  ensureCacheDir();
+  const cachePath = join(CACHE_DIR, `${cacheKey}.png`);
+  // Node.js writeFileSync accepts Buffer/Uint8Array
+  writeFileSync(cachePath, pngBuffer as Uint8Array);
+}

--- a/src/utils/ogImageCache.ts
+++ b/src/utils/ogImageCache.ts
@@ -4,6 +4,9 @@ import { join } from "node:path";
 
 const CACHE_DIR = "cache/og-images";
 
+// Bump when OG template changes to invalidate cache
+const OG_TEMPLATE_VERSION = "v1";
+
 function ensureCacheDir(): void {
   if (!existsSync(CACHE_DIR)) {
     mkdirSync(CACHE_DIR, { recursive: true });
@@ -12,10 +15,11 @@ function ensureCacheDir(): void {
 
 export function generateCacheKey(
   title: string,
-  date: Date,
+  author: string,
+  siteTitle: string,
   theme: string
 ): string {
-  const content = `${title}-${date.toISOString()}-${theme}`;
+  const content = `${OG_TEMPLATE_VERSION}-${title}-${author}-${siteTitle}-${theme}`;
   return createHash("sha256").update(content).digest("hex").slice(0, 16);
 }
 


### PR DESCRIPTION
## Summary

Closes #57

- Add filesystem cache for generated OG images to avoid regeneration on each build
- Add local cache for Google Fonts to reduce network requests
- Configure persistent cache directory outside node_modules for better cache survival
- Improve cache invalidation logic for OG images and fonts

## Test plan
- [x] `just qa` passes locally
- [x] CI passes
- [x] Build time is reduced on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)