### PR TITLE
style(links): use subtle solid underlines

### DIFF
--- a/dev_notes/backlog.md
+++ b/dev_notes/backlog.md
@@ -11,15 +11,17 @@ description: "BACKLOG, todo"
 
 =—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=
 
-use graphite in my workflow ?
-
-https://graphite.com
+Liens: soulignement trop épais → amincir + utiliser couleur primaire
 
 =—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=
 
-table des matieres
+ Choisir mes 5 meilleurs posts, les relire, les mettre en avant
 
-basé sur http://localhost:4320/blog/crypto-in-montreal/#faq-questions-et-reponses
+
+=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=
+
+ Graphite (git stacking) — graphite.com
+https://graphite.com
 
 =—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=
 
@@ -40,9 +42,8 @@ attention à : La génération pas de casque... celle née avant 1990
 
 =—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=
 
-Add MCP
-
-https://docs.astro.build/en/guides/build-with-ai/
+Add MCP, maybe ? 
+MCP Astro AI — docs.astro.build/en/guides/build-with-ai/
 
 =—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=
 
@@ -66,12 +67,9 @@ https://docs.astro.build/en/guides/integrations-guide/sitemap/
 
 =—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=
 
-SEO stuff
+SEO — 0o0o quoi exactement? audit? meta tags? schema?
+
+Ajouter sitemap Astro
 
 =—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=—=
 
-Sponsorships   Loading
-Sponsorships help your community know how to financially support this repository.
-
-Display a "Sponsor" button
-Add links to GitHub Sponsors or third-party methods your repository accepts for financial contributions to your project.

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -18,7 +18,7 @@ const { title, description } = data;
     data-astro-prefetch="viewport"
     class:list={[
       "inline-block text-lg font-medium text-accent",
-      "decoration-dashed underline-offset-4 hover:underline",
+      "decoration-muted-foreground/30 decoration-solid decoration-1 underline-offset-4 hover:underline hover:decoration-accent",
       "focus-visible:no-underline focus-visible:underline-offset-0",
     ]}
   >

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -19,7 +19,7 @@ import { SITE } from "@/config";
       <p class="mt-4 text-2xl sm:text-3xl">Page Not Found</p>
       <LinkButton
         href="/"
-        class="my-6 text-lg underline decoration-dashed underline-offset-8"
+        class="my-6 text-lg underline decoration-muted-foreground/30 decoration-solid decoration-1 underline-offset-8 hover:decoration-accent"
       >
         Go back home
       </LinkButton>

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -28,7 +28,7 @@
     }
 
     a {
-      @apply wrap-break-word text-foreground decoration-dashed underline-offset-4 hover:text-accent focus-visible:no-underline;
+      @apply wrap-break-word text-foreground decoration-muted-foreground/30 decoration-solid decoration-1 underline-offset-4 hover:text-accent hover:decoration-accent focus-visible:no-underline;
     }
 
     ul {


### PR DESCRIPTION
## Summary
- Replace decoration-dashed with thin solid underlines (1px, 30% opacity)
- Adds accent color on hover for better visual feedback
- Applied to blog content, cards, and 404 page

## Files changed
- `src/styles/typography.css` - Blog prose links
- `src/components/Card.astro` - Blog card links
- `src/pages/404.astro` - 404 page link

## Test plan
- [ ] Visit blog post with links and verify subtle underlines
- [ ] Hover links to confirm accent color appears
- [ ] Check 404 page link styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)